### PR TITLE
feat: add two clustering datasets

### DIFF
--- a/mteb/tasks/Clustering/FloresClusteringS2S.py
+++ b/mteb/tasks/Clustering/FloresClusteringS2S.py
@@ -16,5 +16,5 @@ class FloresClusteringS2S(AbsTaskClustering):
             "eval_splits": ["test"],
             "eval_langs": ["es"],
             "main_score": "v_measure",
-            "revision": "b5d0b2bd6ba007bc9145120b47818e3d3e5d1735",
+            "revision": "480b580487f53a46f881354a8348335d4edbb2de",
         }

--- a/mteb/tasks/Clustering/FloresClusteringS2S.py
+++ b/mteb/tasks/Clustering/FloresClusteringS2S.py
@@ -1,0 +1,20 @@
+from ...abstasks.AbsTaskClustering import AbsTaskClustering
+
+
+class FloresClusteringS2S(AbsTaskClustering):
+    @property
+    def description(self):
+        return {
+            "name": "FloresClusteringS2S",
+            "hf_hub_name": "jinaai/flores_clustering",
+            "description": (
+                "Clustering of sentences from various web articles, 32 topics in total."
+            ),
+            "reference": "https://huggingface.co/datasets/facebook/flores",
+            "type": "Clustering",
+            "category": "s2s",
+            "eval_splits": ["test"],
+            "eval_langs": ["es"],
+            "main_score": "v_measure",
+            "revision": "b5d0b2bd6ba007bc9145120b47818e3d3e5d1735",
+        }

--- a/mteb/tasks/Clustering/SpanishNewsClusteringP2P.py
+++ b/mteb/tasks/Clustering/SpanishNewsClusteringP2P.py
@@ -1,0 +1,20 @@
+from ...abstasks.AbsTaskClustering import AbsTaskClustering
+
+
+class SpanishNewsClusteringP2P(AbsTaskClustering):
+    @property
+    def description(self):
+        return {
+            "name": "SpanishNewsClusteringP2P",
+            "hf_hub_name": "jinaai/spanish_news_clustering",
+            "description": (
+                "Clustering of news articles, 7 topics in total."
+            ),
+            "reference": "https://www.kaggle.com/datasets/kevinmorgado/spanish-news-classification",
+            "type": "Clustering",
+            "category": "p2p",
+            "eval_splits": ["test"],
+            "eval_langs": ["es"],
+            "main_score": "v_measure",
+            "revision": "b5edc3d3d7c12c7b9f883e9da50f6732f3624142",
+        }

--- a/mteb/tasks/Clustering/__init__.py
+++ b/mteb/tasks/Clustering/__init__.py
@@ -17,3 +17,5 @@ from .CMTEBClustering import *
 from .PolishClustering import *
 from .BigPatentClustering import *
 from .WikiCitiesClustering import *
+from .FloresClusteringS2S import *
+from .SpanishNewsClusteringP2P import *


### PR DESCRIPTION
Adding two clustering datasets:
https://huggingface.co/datasets/facebook/flores
and 
https://www.kaggle.com/datasets/kevinmorgado/spanish-news-classification

Note:
we normalized topics in flores by 1. lowercasing them, 2. removing subcategories ('travel, expenses' -> 'travel') and 3. dropping every category with less than 15 examples