### PR TITLE
feat: add miracl reranking task for spanish

### DIFF
--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -30,8 +30,9 @@ class MIRACLReranking(AbsTaskReranking):
         if self.data_loaded:
             return
 
-        # TODO: add split argument
         self.dataset = datasets.load_dataset(
-            self.description["hf_hub_name"], 'es', revision=self.description.get("revision", None)
+            self.description["hf_hub_name"],
+            self.description['eval_lags'][0],
+            revision=self.description.get("revision", None),
         )
         self.data_loaded = True

--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -20,7 +20,7 @@ class MIRACLReranking(AbsTaskReranking):
             'eval_splits': ['test'],
             'eval_langs': ['es'],
             'main_score': 'map',
-            'revision': '',
+            'revision': 'd28a029f35c4ff7f616df47b0edf54e6882395e6',
         }
 
     def load_data(self, **kwargs):

--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -8,7 +8,7 @@ class MIRACLReranking(AbsTaskReranking):
     def description(self):
         return {
             'name': 'MIRACL',
-            'hf_hub_name': 'jinaai/miracl-es',
+            'hf_hub_name': 'jinaai/miracl',
             'reference': 'https://project-miracl.github.io/',
             'description': (
                 'MIRACL (Multilingual Information Retrieval Across a Continuum of Languages) is a multilingual '

--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -1,3 +1,5 @@
+import datasets
+
 from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
 
 
@@ -20,3 +22,16 @@ class MIRACLReranking(AbsTaskReranking):
             'main_score': 'map',
             'revision': '',
         }
+
+    def load_data(self, **kwargs):
+        """
+        Load dataset from HuggingFace hub
+        """
+        if self.data_loaded:
+            return
+
+        # TODO: add split argument
+        self.dataset = datasets.load_dataset(
+            self.description["hf_hub_name"], 'es', revision=self.description.get("revision", None)
+        )
+        self.data_loaded = True

--- a/mteb/tasks/Reranking/MIRACLReranking.py
+++ b/mteb/tasks/Reranking/MIRACLReranking.py
@@ -1,0 +1,22 @@
+from mteb.abstasks.AbsTaskReranking import AbsTaskReranking
+
+
+class MIRACLReranking(AbsTaskReranking):
+    @property
+    def description(self):
+        return {
+            'name': 'MIRACL',
+            'hf_hub_name': 'jinaai/miracl-es',
+            'reference': 'https://project-miracl.github.io/',
+            'description': (
+                'MIRACL (Multilingual Information Retrieval Across a Continuum of Languages) is a multilingual '
+                'retrieval dataset that focuses on search across 18 different languages. This task focuses on '
+                'the Spanish subset, using the test set containing 648 queries and 6443 passages.'
+            ),
+            'type': 'Reranking',
+            'category': 's2p',
+            'eval_splits': ['test'],
+            'eval_langs': ['es'],
+            'main_score': 'map',
+            'revision': '',
+        }

--- a/mteb/tasks/Reranking/__init__.py
+++ b/mteb/tasks/Reranking/__init__.py
@@ -3,3 +3,4 @@ from .MindSmallReranking import *
 from .SciDocsReranking import *
 from .StackOverflowDupQuestions import *
 from .CMTEBReranking import *
+from .MIRACLReranking import *


### PR DESCRIPTION
This PR adds the MIRACL Reranking task.

Some results for this task:

| model | map | mrr | evaluation_time |
| --- | --- | --- | --- |
| multilingual-e5-base | 73.48 % |  81.33% | 18.2 |
| multilingual-e5-large | 75.56 % | 83.71% | 48.91 |